### PR TITLE
Add identity gates on non-operated qubits 

### DIFF
--- a/mpqp/core/circuit.py
+++ b/mpqp/core/circuit.py
@@ -684,7 +684,7 @@ class QCircuit:
         elif language == Language.BRAKET:
             circuit = deepcopy(self)
             used_qubits = set().union(
-                inst.connections() for inst in circuit.instructions
+                *(inst.connections() for inst in circuit.instructions)
             )
             circuit.add(
                 [

--- a/tests/execution/providers_execution/test_aws_execution.py
+++ b/tests/execution/providers_execution/test_aws_execution.py
@@ -1,1 +1,20 @@
 # 3M-TODO
+import pytest
+
+from mpqp import QCircuit
+from mpqp.gates import *
+from mpqp.execution import run, AWSDevice
+
+
+@pytest.mark.parametrize(
+    "circuit",
+    [
+        QCircuit([H(2)]),
+        QCircuit([H(0), H(2)]),
+        QCircuit([H(0), CNOT(1, 3), H(2)]),
+        QCircuit([H(2)], nb_qubits=5),
+    ]
+)
+def test_braket_non_contiguous_qubits(circuit: QCircuit):
+    run(circuit, AWSDevice.BRAKET_LOCAL_SIMULATOR)
+


### PR DESCRIPTION
When translating the circuit to a Braket circuit, to avoid non-contiguous qubit error at execution