### PR TITLE
New feature: automated mac install

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -26,7 +26,7 @@ is not supported, so your milage may vary).
 
         curl -L https://raw.githubusercontent.com/ColibrITD-SAS/mpqp/main/mac-install.sh | bash -s -- <your-python-bin>
         
-    where ``<your-python-bin>`` is the binary you use to invoke python. I could 
+    where ``<your-python-bin>`` is the binary you use to invoke python. It could
     for instance be ``python``, ``python3``, ``python3.9``, etc...
 
 Your first circuit

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -53,17 +53,12 @@ Setup remote connection
 
 After you installed MPQP package using ``pip install``, the script
 :mod:`setup_connections.py<mpqp.execution.connection.setup_connections>` can be
-called from everywhere, not only in ``mpqp`` folder, using the following command
-line:
+called to setup your connection to the remote backends supported, using the
+following command:
 
 .. code-block:: console
 
     $ setup_connections
-
-This script will allow you to configure and save your personal account to
-connect to remote machines. Depending on the provider, different credentials can
-be asked. Information concerning which provider is configured and related
-credentials are stored in the ``~/.mpqp`` file.
 
 IBM Quantum
 ^^^^^^^^^^^

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -7,9 +7,9 @@ Installation
 .. TODO: grab the compatibility matrix from MyQLM and relax our requirements 
 .. when possible, test on many different configurations (tox or other ?)
 
-For now, we support python versions 3.9 to 3.11, and both Windows and Linux
-(specifically, if was validated on Ubuntu LTS 20.04, while Ubuntu 18.04 is not
-supported). MacOS versions will come very soon!
+For now, we support python versions 3.9 to 3.11, and both Windows, Linux and 
+MacOS (specifically, Linux was validated on Ubuntu LTS 20.04, while Ubuntu 18.04 
+is not supported, so your milage may vary).
 
 .. code-block:: console
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -15,6 +15,20 @@ supported). MacOS versions will come very soon!
 
    $ pip install mpqp
 
+.. note::
+    For mac users, additional steps are required before the installation, 
+    specifically because of the ``myqlm`` library. To run these steps, you can 
+    either follow their instructions on 
+    `this page <https://myqlm.github.io/01_getting_started/%3Amyqlm%3Amacos.html#macos>`_
+    or run the script we created to facilitate this step:
+
+    .. code-block:: bash
+
+        curl -L https://raw.githubusercontent.com/ColibrITD-SAS/mpqp/main/mac-install.sh | bash -s -- <your-python-bin>
+        
+    where ``<your-python-bin>`` is the binary you use to invoke python. I could 
+    for instance be ``python``, ``python3``, ``python3.9``, etc...
+
 Your first circuit
 ------------------
 

--- a/mac-install.sh
+++ b/mac-install.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
 
 if [[ $# -eq 0 ]]; then
 	echo "Please pass as argument to this script the python binary you want to install mpqp to."
 	echo "For example:"
 	echo "    $ ./mac-install.sh python3"
+	exit 1
 fi
 python_exec=$1
 brew install cmake libomp

--- a/mac-install.sh
+++ b/mac-install.sh
@@ -15,4 +15,4 @@ if [[ ! -f /usr/local/lib/libomp.dylib ]]; then
 	sudo mkdir /usr/local/lib
 	sudo ln -sf $libom_location/$version/lib/libomp.dylib /usr/local/lib/libomp.dylib
 fi
-pip $python_exec -p pip install mpqp
+$python_exec -m pip install mpqp

--- a/mac-install.sh
+++ b/mac-install.sh
@@ -1,10 +1,16 @@
-brew install python@3.9 cmake libomp
-echo "alias python=python3.9" >> ~/.zprofile
-echo "alias pip=pip3.9" >> ~/.zprofile
-source ~/.zprofile
-brew_dir=$(which brew | sed 's/\/bin\/brew//g')
-libom_location=$brew_dir/Cellar/libomp
-version=$(ls $libom_location)
-sudo mkdir /usr/local/lib
-sudo ln -sf $libom_location/$version/lib/libomp.dylib /usr/local/lib/libomp.dylib
-pip install mpqp
+
+if [[ $# -eq 0 ]]; then
+	echo "Please pass as argument to this script the python binary you want to install mpqp to."
+	echo "For example:"
+	echo "    $ ./mac-install.sh python3"
+fi
+python_exec=$1
+brew install cmake libomp
+if [[ ! -f /usr/local/lib/libomp.dylib ]]; then
+	brew_dir=$(which brew | sed 's/\/bin\/brew//g')
+	libom_location=$brew_dir/Cellar/libomp
+	version=$(ls $libom_location)
+	sudo mkdir /usr/local/lib
+	sudo ln -sf $libom_location/$version/lib/libomp.dylib /usr/local/lib/libomp.dylib
+fi
+pip $python_exec -p pip install mpqp

--- a/mac-install.sh
+++ b/mac-install.sh
@@ -1,0 +1,10 @@
+brew install python@3.9 cmake libomp
+echo "alias python=python3.9" >> ~/.zprofile
+echo "alias pip=pip3.9" >> ~/.zprofile
+source ~/.zprofile
+brew_dir=$(which brew | sed 's/\/bin\/brew//g')
+libom_location=$brew_dir/Cellar/libomp
+version=$(ls $libom_location)
+sudo mkdir /usr/local/lib
+sudo ln -sf $libom_location/$version/lib/libomp.dylib /usr/local/lib/libomp.dylib
+pip install mpqp

--- a/mpqp/execution/connection/setup_connections.py
+++ b/mpqp/execution/connection/setup_connections.py
@@ -1,4 +1,11 @@
 #! /usr/bin/env python3
+"""This script helps you configuring the connections for all the supported 
+remote backends. In time, it will also guide you to retrieve the tokens,
+passwords, etc... but for now, it is a prerequisite that you already have these
+credentials to use this script.
+
+Information concerning which provider is configured and related
+credentials are stored in the ``~/.mpqp`` file."""
 
 import mpqp.execution.connection.aws_connection as awsc
 import mpqp.execution.connection.env_manager as env_m


### PR DESCRIPTION
On MacOS, some dependencies could not be installed by pip, requiring an external step. For this reason, is was said to not be supported so far. Now, with the additional note in the documentation and the script to automate those steps, we can say that we officially support MPQP on MacOS !