### PR TITLE
Update doc.yml

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_publish_docs:
     # Deploy to cloudflare
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'release' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The doc deployment was previously restricted to only run on PR events if the PR was accepted, but this check meant that this would never pass for new versions. This was fixed by adding a option on the run condition in case we are in the release event case