### PR TITLE
Feat: Statevector to sample list

### DIFF
--- a/mpqp/execution/result.py
+++ b/mpqp/execution/result.py
@@ -125,7 +125,11 @@ class StateVector:
             [Sample(2, index=0, count=None, probability=0.5), Sample(2, index=3, count=None, probability=0.5)]
 
         """
-        pass  
+        return [
+            Sample(self.nb_qubits, index=index, probability=proba)
+            for index, proba in enumerate(self.probabilities)
+            if not np.isclose(proba, 0)
+        ] 
 
     def __eq__(self, other) -> bool:  # pyright: ignore[reportMissingParameterType]
         if not isinstance(other, StateVector):

--- a/mpqp/execution/result.py
+++ b/mpqp/execution/result.py
@@ -106,6 +106,21 @@ class StateVector:
             "nb_qubits": self.nb_qubits,
         }
 
+    def to_sample_list(self) -> list[Sample]:
+        """
+        Converts the StateVector object into a list of Samples. This allows 
+        to quickly have a binary representation of the basis states composing
+        a StateVector. 
+        
+        Note that the samples will be instantiated with probabilities, so
+        we cannot come back after that to the StateVector amplitudes.
+
+        Returns:
+            A list of Samples representing the possible measurement outcomes 
+            of the state represented by this StateVector.
+        """
+        pass  
+
     def __eq__(self, other) -> bool:  # pyright: ignore[reportMissingParameterType]
         if not isinstance(other, StateVector):
             return False

--- a/mpqp/execution/result.py
+++ b/mpqp/execution/result.py
@@ -118,6 +118,12 @@ class StateVector:
         Returns:
             A list of Samples representing the possible measurement outcomes 
             of the state represented by this StateVector.
+
+        Example:
+            >>> state_vector = StateVector(np.array([1, 0, 0, -1])/np.sqrt(2), 2)
+            >>> state_vector.to_sample_list()
+            [Sample(2, index=0, count=None, probability=0.5), Sample(2, index=3, count=None, probability=0.5)]
+
         """
         pass  
 


### PR DESCRIPTION
I was trying to use StateVector to do some computations and analysis, but it was not convenient to each time having to parse the numpy array to deduce what are the basis states.
I saw you had Samples, so I added a method to get a list of samples so I can look at their binary representation directly