### PR TITLE
Fix: QCircuit Initializer simplification of U Gates 

### DIFF
--- a/mpqp/core/circuit.py
+++ b/mpqp/core/circuit.py
@@ -927,7 +927,7 @@ class QCircuit:
 
         Examples:
             >>> qc = QCircuit.initializer(np.array([1, 0, 0 ,1])/np.sqrt(2))
-            >>> print(qc)
+            >>> print(qc) # doctest: +NORMALIZE_WHITESPACE
                    ┌─────────┐
             q_0: ──┤ Ry(π/2) ├─────■─────────────
                  ┌─┴─────────┴──┐┌─┴─┐┌─────────┐

--- a/mpqp/core/circuit.py
+++ b/mpqp/core/circuit.py
@@ -928,7 +928,7 @@ class QCircuit:
         Examples:
             >>> qc = QCircuit.initializer(np.array([1, 0, 0 ,1])/np.sqrt(2))
             >>> print(qc)
-                   ┌─────────┐                   
+                   ┌─────────┐
             q_0: ──┤ Ry(π/2) ├─────■─────────────
                  ┌─┴─────────┴──┐┌─┴─┐┌─────────┐
             q_1: ┤ U(π/2,π/2,π) ├┤ X ├┤ Rx(π/2) ├

--- a/mpqp/core/circuit.py
+++ b/mpqp/core/circuit.py
@@ -917,24 +917,22 @@ class QCircuit:
 
     @classmethod
     def initializer(cls, state: npt.NDArray[np.complex128]) -> QCircuit:
-        """Initialize this circuit at a given state, given in parameter.
-        This will imply adding gates at the beginning of the circuit.
+        """Build a circuit preparing the given state from the all-zero state.
 
         Args:
-            state: StateVector modeling the state for initializing the circuit.
+            state: State vector to prepare. It is normalized before synthesis.
 
         Returns:
-            A copy of the input circuit with additional instructions added
-            before-hand to generate the right initial state.
+            A circuit made of simplified native gates preparing ``state``.
 
         Examples:
             >>> qc = QCircuit.initializer(np.array([1, 0, 0 ,1])/np.sqrt(2))
-            >>> print(qc)  # doctest: +SKIP
-                   ┌────────────┐
-            q_0: ──┤ U(π/2,0,0) ├────■──────────────────────────
-                 ┌─┴────────────┴─┐┌─┴─┐┌──────────────────────┐
-            q_1: ┤ U(0,-π/4,-π/4) ├┤ X ├┤ U(0,-6.8934,0.61023) ├
-                 └────────────────┘└───┘└──────────────────────┘
+            >>> print(qc)
+                   ┌─────────┐                   
+            q_0: ──┤ Ry(π/2) ├─────■─────────────
+                 ┌─┴─────────┴──┐┌─┴─┐┌─────────┐
+            q_1: ┤ U(π/2,π/2,π) ├┤ X ├┤ Rx(π/2) ├
+                 └──────────────┘└───┘└─────────┘
             >>> pprint(run(qc, IBMDevice.AER_SIMULATOR_STATEVECTOR).amplitudes)
             [0.70711, 0, 0, 0.70711]
         """
@@ -942,6 +940,7 @@ class QCircuit:
         from qiskit.circuit.library import StatePreparation
         from qiskit.quantum_info import Statevector
 
+        from mpqp.core.instruction.gates import Id, U
         from mpqp.tools.circuit import replace_custom_gate
         from mpqp.tools.maths import normalize
 
@@ -954,9 +953,17 @@ class QCircuit:
             StatePreparation(Statevector(normalize(state))), range(size)
         )
         circ, phase = replace_custom_gate(qiskit_circuit, size, list(range(size)))
-        cls = QCircuit.from_other_language(circ.reverse_bits())
-        cls.input_g_phase = phase
-        return cls
+        circuit = QCircuit.from_other_language(circ.reverse_bits())
+        simplified_instructions: list[Instruction] = []
+        for instruction in circuit.instructions:
+            simplified = (
+                instruction.simplify() if isinstance(instruction, U) else instruction
+            )
+            if not isinstance(simplified, Id):
+                simplified_instructions.append(simplified)
+        circuit.instructions = simplified_instructions
+        circuit.input_g_phase = phase
+        return circuit
 
     def count_gates(self, gate: Optional[Type[Gate]] = None) -> int:
         """Returns the number of gates contained in the circuit. If a specific

--- a/mpqp/core/instruction/gates/native_gates.py
+++ b/mpqp/core/instruction/gates/native_gates.py
@@ -55,6 +55,7 @@ from mpqp.tools.generics import Matrix, SimpleClassReprABC, classproperty
 from mpqp.tools.maths import (
     cos,
     exp,
+    matrix_eq,
     sin,
     symbolic_product,
     symbolic_divide,
@@ -1207,6 +1208,59 @@ class U(NativeGate, ParametrizedGate, SingleQubitGate):
                 [ep * s, eg * ep * c],  # pyright: ignore[reportOperatorIssue]
             ]
         )
+
+    def simplify(self) -> NativeGate:
+        """Return the simplest native gate exactly equivalent to this gate.
+
+        ``U`` is useful as a universal one-qubit gate, but decompositions often
+        emit it for operations already represented by a more specific MPQP
+        native gate.  Numeric comparisons use the same tolerance as
+        :func:`~mpqp.tools.maths.matrix_eq`; symbolic rotations are simplified
+        when their matrices can be proven equal.
+
+        Returns:
+            A more specific native gate when one is equivalent, otherwise this
+            gate itself.
+
+        Examples:
+            >>> type(U(0, 0, 0, 1).simplify()).__name__
+            'Id'
+            >>> type(U(np.pi / 2, 0, np.pi, 1).simplify()).__name__
+            'H'
+            >>> type(U(0.3, 0, 0, 1).simplify()).__name__
+            'Ry'
+        """
+        target = self.targets[0]
+        candidates: list[NativeGate] = [
+            Id(target),
+            X(target),
+            Y(target),
+            Z(target),
+            H(target),
+            S(target),
+            S_dagger(target),
+            T(target),
+            Rx(self.theta, target),
+            Ry(self.theta, target),
+            P(self.phi + self.gamma, target), # pyright: ignore[reportOperatorIssue]
+        ]
+
+        source_matrix = self.to_matrix()
+        for candidate in candidates:
+            candidate_matrix = candidate.to_matrix()
+            try:
+                # Sympy numeric constants and numpy scalars do not always
+                # compare reliably when kept in object arrays.
+                equivalent = matrix_eq(
+                    np.asarray(source_matrix, dtype=np.complex128),
+                    np.asarray(candidate_matrix, dtype=np.complex128),
+                )
+            except (TypeError, ValueError):
+                equivalent = matrix_eq(source_matrix, candidate_matrix)
+            if equivalent:
+                return candidate
+
+        return self
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.theta}, {self.phi}, {self.gamma}, {self.targets[0]})"

--- a/mpqp/core/instruction/gates/native_gates.py
+++ b/mpqp/core/instruction/gates/native_gates.py
@@ -1242,7 +1242,7 @@ class U(NativeGate, ParametrizedGate, SingleQubitGate):
             T(target),
             Rx(self.theta, target),
             Ry(self.theta, target),
-            P(self.phi + self.gamma, target), # pyright: ignore[reportOperatorIssue]
+            P(self.phi + self.gamma, target),  # pyright: ignore[reportOperatorIssue]
         ]
 
         source_matrix = self.to_matrix()

--- a/tests/core/instruction/gates/test_native_gates.py
+++ b/tests/core/instruction/gates/test_native_gates.py
@@ -3,6 +3,7 @@ import pytest
 from sympy import Expr, I, pi, symbols
 
 from mpqp.gates import *
+from mpqp.core.instruction.gates.native_gates import NativeGate
 from mpqp.tools.generics import Matrix
 from mpqp.tools.maths import cos, exp, matrix_eq, sin
 
@@ -61,6 +62,38 @@ def test_P(angle: float, result_matrix: Matrix):
 )
 def test_U(theta: float, phi: float, gamma: float, result_matrix: Matrix):
     assert matrix_eq(U(theta, phi, gamma, 0).to_matrix(), result_matrix)
+
+
+@pytest.mark.parametrize(
+    "gate, expected_type",
+    [
+        (U(0, 0, 0, 1), Id),
+        (U(np.pi, 0, np.pi, 1), X),
+        (U(np.pi, np.pi / 2, np.pi / 2, 1), Y),
+        (U(0, 0, np.pi, 1), Z),
+        (U(np.pi / 2, 0, np.pi, 1), H),
+        (U(0, 0, np.pi / 2, 1), S),
+        (U(0, 0, -np.pi / 2, 1), S_dagger),
+        (U(0, 0, np.pi / 4, 1), T),
+        (U(0.3, -np.pi / 2, np.pi / 2, 1), Rx),
+        (U(0.3, 0, 0, 1), Ry),
+        (U(0, 0.1, 0.2, 1), P),
+        (U(theta, 0, 0, 1), Ry),
+        (U(0.3, 0.1, 0.2, 1), U),
+    ],
+)
+def test_U_simplify(gate: U, expected_type: type[NativeGate]):
+    simplified = gate.simplify()
+
+    assert type(simplified) is expected_type
+    assert simplified.targets == gate.targets
+    try:
+        assert np.allclose(
+            np.asarray(simplified.to_matrix(), dtype=np.complex128),
+            np.asarray(gate.to_matrix(), dtype=np.complex128),
+        )
+    except (TypeError, ValueError):
+        assert matrix_eq(simplified.to_matrix(), gate.to_matrix())
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_circuit.py
+++ b/tests/core/test_circuit.py
@@ -437,11 +437,27 @@ def states() -> list[npt.NDArray[np.complex128]]:
 def test_initializer(states: list[npt.NDArray[np.complex128]]):
     for state in states:
         qc = QCircuit.initializer(state)
+        assert all(not isinstance(gate, Id) for gate in qc.gates)
         res = run(qc, IBMDevice.AER_SIMULATOR_STATEVECTOR)
         if TYPE_CHECKING:
             assert isinstance(res, Result)
         state_vector_initialized = res.state_vector.vector
         assert matrix_eq(state, state_vector_initialized)
+
+
+@pytest.mark.provider("qiskit")
+@pytest.mark.parametrize(
+    "state",
+    [
+        np.array([1, 0]),
+        np.array([0, 1]),
+        np.array([1, 1]) / np.sqrt(2),
+    ],
+)
+def test_initializer_simplifies_u_gates(state: npt.NDArray[np.complex128]):
+    circuit = QCircuit.initializer(state)
+
+    assert all(not isinstance(gate, (Id, U)) for gate in circuit.gates)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The U Gates have now a simplify function that translate itself into a native gate. 
But it can't translate several U into one native gates, so the simplification isn't great.